### PR TITLE
feat(metallb): updated to 0.13.0

### DIFF
--- a/.ci/version-lock
+++ b/.ci/version-lock
@@ -1,7 +1,7 @@
 # Core Version
-argocd_version=4.10.3
-sealed_secrets_version=2.5.2
-kubevirt_version=v0.55.0-rc.0
+argocd_version=4.10.5
+sealed_secrets_version=2.6.0
+kubevirt_version=v0.56.0-rc.0
 coredns_version=1.9.3
 
 # Utils Version
@@ -12,11 +12,11 @@ etcdctl_version=v3.5.4
 
 # Apps
 local_path_provisioner_version=v0.0.22
-kube_prometheus_stack_version=39.2.0
+kube_prometheus_stack_version=39.5.0
 
 # cfctl.yaml
-k0s_version=1.24.2+k0s.0
-metallb_version=3.0.12
+k0s_version=1.24.3+k0s.0
+metallb_version=4.0.1
 traefik_version=10.24.0
 cert_manager_version=v1.9.1
 csi_driver_nfs_version=v4.1.0

--- a/argo.example/monitoring/apps/prometheus-crd-app.yml
+++ b/argo.example/monitoring/apps/prometheus-crd-app.yml
@@ -10,7 +10,7 @@ spec:
   source:
     repoURL: https://github.com/prometheus-community/helm-charts.git
     path: charts/kube-prometheus-stack/crds/
-    targetRevision: kube-prometheus-stack-39.2.0
+    targetRevision: kube-prometheus-stack-39.5.0
 
     directory:
       recurse: true

--- a/cfctl.yaml.example
+++ b/cfctl.yaml.example
@@ -25,7 +25,7 @@ spec:
             - sh -c 'if [ "$(getenforce)" != "Permissive" ] && [ "$(getenforce)" != "Disabled" ]; then setenforce 0; fi'
 
   k0s:
-    version: '1.24.2+k0s.0'
+    version: '1.24.3+k0s.0'
     dynamicConfig: false
     config:
       apiVersion: k0s.k0sproject.io/v1beta1
@@ -85,7 +85,7 @@ spec:
             charts:
               - name: metallb
                 chartname: bitnami/metallb
-                version: '3.0.12'
+                version: '4.0.1'
                 namespace: metallb
                 values: |
                   configInline:

--- a/cfctl.yaml.example
+++ b/cfctl.yaml.example
@@ -87,22 +87,6 @@ spec:
                 chartname: bitnami/metallb
                 version: '4.0.1'
                 namespace: metallb
-                values: |
-                  configInline:
-                    peers:
-                      - peer-address: 192.168.0.1
-                        peer-asn: 65000
-                        my-asn: 65001
-                        source-address: 192.168.0.2
-                        node-selectors:
-                          - match-labels:
-                              kubernetes.io/hostname: mn1.example.com
-
-                    address-pools:
-                      - name: main-pool
-                        protocol: bgp
-                        addresses:
-                          - 192.168.1.100/32
 
               - name: traefik
                 chartname: traefik/traefik

--- a/core.example/argo-cd/install.sh
+++ b/core.example/argo-cd/install.sh
@@ -8,7 +8,7 @@ helm repo update
 helm upgrade --install \
   -n argocd \
   -f "${BASEDIR}/values.yaml" \
-  --version 4.10.3 \
+  --version 4.10.5 \
   argocd \
   argo/argo-cd \
   --create-namespace

--- a/core.example/kubevirt/base/kustomization.yaml
+++ b/core.example/kubevirt/base/kustomization.yaml
@@ -1,3 +1,3 @@
 resources:
-  - https://github.com/kubevirt/kubevirt/releases/download/v0.55.0-rc.0/kubevirt-operator.yaml
-  - https://github.com/kubevirt/kubevirt/releases/download/v0.55.0-rc.0/kubevirt-cr.yaml
+  - https://github.com/kubevirt/kubevirt/releases/download/v0.56.0-rc.0/kubevirt-operator.yaml
+  - https://github.com/kubevirt/kubevirt/releases/download/v0.56.0-rc.0/kubevirt-cr.yaml

--- a/core.example/metallb/address-pools.yaml
+++ b/core.example/metallb/address-pools.yaml
@@ -1,0 +1,8 @@
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: main-pool
+  namespace: metallb
+spec:
+  addresses:
+    - 192.168.1.100/32

--- a/core.example/metallb/advertisements.yaml
+++ b/core.example/metallb/advertisements.yaml
@@ -1,0 +1,8 @@
+apiVersion: metallb.io/v1beta1
+kind: BGPAdvertisement
+metadata:
+  name: bgp-advertisement
+  namespace: metallb
+spec:
+  ipAddressPools:
+    - main-pool

--- a/core.example/metallb/peers.yaml
+++ b/core.example/metallb/peers.yaml
@@ -1,0 +1,13 @@
+apiVersion: metallb.io/v1beta2
+kind: BGPPeer
+metadata:
+  name: main-router
+  namespace: metallb
+spec:
+  myASN: 65001 # MetalLB Speaker ASN (Autonomous System Number)
+  nodeSelectors:
+    - matchLabels:
+        kubernetes.io/hostname: mn1.example.com # The speaker node, which is the entrypoint.
+  peerASN: 65000 # The router ASN
+  peerAddress: 192.168.0.1 # The router address
+  sourceAddress: 192.168.0.2 # The speaker node IP, which is used to identity the network interface of the node.

--- a/core.example/sealed-secrets/install.sh
+++ b/core.example/sealed-secrets/install.sh
@@ -5,7 +5,7 @@ helm repo update
 
 helm upgrade --install \
   -n sealed-secrets \
-  --version 2.5.2 \
+  --version 2.6.0 \
   sealed-secrets \
   sealed-secrets/sealed-secrets \
   --create-namespace

--- a/helm-subcharts/kube-prometheus-stack/Chart.yaml
+++ b/helm-subcharts/kube-prometheus-stack/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kube-prometheus-stack-subchart
 description: Kube Prometheus Stack subchart
 type: application
-version: 39.2.0
+version: 39.5.0
 appVersion: '36.2.1'
 
 dependencies:

--- a/web/docs/getting-started/03-k0s-configuration.md
+++ b/web/docs/getting-started/03-k0s-configuration.md
@@ -44,7 +44,7 @@ After you set the `hosts` field, you must configure the k0s architecture by edit
 
 ```yaml title="cfctl.yaml > spec > k0s"
 k0s:
-  version: '1.24.2+k0s.0'
+  version: '1.24.3+k0s.0'
   dynamicConfig: false
   config:
     apiVersion: k0s.k0sproject.io/v1beta1
@@ -123,7 +123,7 @@ Your router must be capable of using BGP. If not, you should use an appliance wi
 ```yaml title="cfctl.yaml > spec > k0s > spec > extensions > helm > charts[]"
 - name: metallb
   chartname: bitnami/metallb
-  version: '3.0.12'
+  version: '4.0.1'
   namespace: metallb
   values: |
 
@@ -156,7 +156,7 @@ Your router must be capable of using BGP. If not, you should use an appliance wi
 ```yaml title="cfctl.yaml > spec > k0s > spec > extensions > helm > charts[]"
 - name: metallb
   chartname: bitnami/metallb
-  version: '3.0.12'
+  version: '4.0.1'
   namespace: metallb
   values: |
 

--- a/web/docs/getting-started/05-argo-apps-deployment.md
+++ b/web/docs/getting-started/05-argo-apps-deployment.md
@@ -257,7 +257,7 @@ spec:
     chart: kube-prometheus-stack
     repoURL: https://github.com/prometheus-community/helm-charts.git
     path: charts/kube-prometheus-stack/crds/
-    targetRevision: kube-prometheus-stack-39.2.0
+    targetRevision: kube-prometheus-stack-39.5.0
 
     directory:
       recurse: true
@@ -292,12 +292,12 @@ apiVersion: v2
 name: kube-prometheus-stack-subchart
 description: Kube Prometheus Stack subchart
 type: application
-version: 39.2.0
+version: 39.5.0
 appVersion: '0.1.2'
 
 dependencies:
   - name: kube-prometheus-stack
-    version: 39.2.0
+    version: 39.5.0
     repository: https://prometheus-community.github.io/helm-charts
 ```
 


### PR DESCRIPTION
Closes #95 and closes #92.

#### Does this PR introduce a user-facing change?

```release-note
feat(metallb): Converted `configInline` to the CRDs
```

Migration instructions:

1. Fetch the MetalLB configMap and store it inside a file `config.yaml`
2. Run the conversion utility using docker:

```shell
docker run -it --rm -v $(pwd):/var/input quay.io/metallb/configmaptocrs -source config.yaml
```

3. Apply the CRDs

```shell
kubectl apply -f .
```